### PR TITLE
nationCreator doesn't work with Hare's RCES

### DIFF
--- a/nationCreator.user.js
+++ b/nationCreator.user.js
@@ -9,7 +9,9 @@
 (function () {
     'use strict';
     if (document.querySelector('#content input[type="submit"]')) {
-        const nation = decodeURIComponent(window.location.href.substring(window.location.href.lastIndexOf('=') + 1));
+        const position = window.location.href.indexOf('nation=') + 7;
+
+        const nation = decodeURIComponent(window.location.href.substring(position, window.location.href.indexOf('/', position)));
         localStorage.setItem('createNation', nation);
         document.querySelector('#content input[type="submit"]').focus()
         return


### PR DESCRIPTION
When using nationCreator with RCES on Hare (https://hare.kractero.com/tools/rces), the created nation name will be `Hare_RCES__author_main_nation_Kractero__usedBy_NDR`

The root cause is that the original script uses the substring after the last index of '=', but the links on RCES have a new `generated_by` parameter.

By the way, I also found out that the links generated by Creation Assistant(https://hare.kractero.com/tools/creation) and Hare's RCES are different. I'm not sure if it is intended or not.